### PR TITLE
entity class 추가(#6)

### DIFF
--- a/src/main/java/com/hanium/hfrecruit/domain/Recruit/Recruit.java
+++ b/src/main/java/com/hanium/hfrecruit/domain/Recruit/Recruit.java
@@ -1,0 +1,63 @@
+package com.hanium.hfrecruit.domain.Recruit;
+
+import com.hanium.hfrecruit.domain.application.Application;
+import com.hanium.hfrecruit.domain.company.CompanyInfo;
+import com.hanium.hfrecruit.domain.company.CompanyUser;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.Date;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Recruit {
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long recruitNo;
+
+    @Column(nullable = false)
+    private String recruitTitle;
+
+    @Column(nullable = false)
+    private String recruitContent;
+
+    @Column(nullable = false)
+    private Date startDate;
+
+    @Column(nullable = false)
+    private Date closedDate;
+
+    @Column(nullable = false)
+    private Integer closedBit;
+
+    @Column(nullable = false)
+    private String question1;
+
+    @Column(nullable = false)
+    private String question2;
+
+    @Column(nullable = false)
+    private String question3;
+
+    private String question4;
+
+    private String question5;
+
+    @ManyToOne
+    @JoinColumn(name = "company_no")
+    private CompanyInfo companyInfo;
+
+
+    @ManyToOne
+    @JoinColumn(name = "company_user_id")
+    private CompanyUser companyUser;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "recruit")
+    private List<Application> applicationList;
+
+}

--- a/src/main/java/com/hanium/hfrecruit/domain/application/Application.java
+++ b/src/main/java/com/hanium/hfrecruit/domain/application/Application.java
@@ -1,0 +1,72 @@
+package com.hanium.hfrecruit.domain.application;
+
+import com.hanium.hfrecruit.domain.Recruit.Recruit;
+import com.hanium.hfrecruit.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Application {
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long applicationId;
+
+    @Column(nullable = false)
+    private Date dateCreated;
+
+    @Column(nullable = false)
+    private Date lastUpdated;
+
+    @Column(nullable = false)
+    private Integer bit;
+
+    @Column(nullable = false)
+    private String question1;
+
+    @Column(nullable = false)
+    private String question2;
+
+    @Column(nullable = false)
+    private String question3;
+
+    private String question4;
+
+    private String question5;
+
+    @Column(nullable = false)
+    private String educationLevel;
+
+    @Column(nullable = false)
+    private String militaryService;
+
+    private String q1Comment;
+
+    private String q2Comment;
+
+    private String q3Comment;
+
+    private String q4Comment;
+
+    private String q5Comment;
+
+    private Integer score;
+
+    private Integer passStage;
+
+    private Integer passOrFail;
+
+    @ManyToOne
+    @JoinColumn(name = "recruit_no")
+    private Recruit recruit;
+
+    @ManyToOne
+    @JoinColumn(name = "user_no")
+    private User user;
+}

--- a/src/main/java/com/hanium/hfrecruit/domain/company/CompanyInfo.java
+++ b/src/main/java/com/hanium/hfrecruit/domain/company/CompanyInfo.java
@@ -1,0 +1,38 @@
+package com.hanium.hfrecruit.domain.company;
+
+
+import com.hanium.hfrecruit.domain.Recruit.Recruit;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class CompanyInfo {
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long companyNo;
+
+    @Column(nullable = false)
+    private String companyName;
+
+    @Column(nullable = false)
+    private String companyEmail;
+
+    @Column(nullable = false)
+    private Integer managerId;
+
+    @Column(nullable = false)
+    private String companyLogo;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "companyInfo")
+    private List<CompanyUser> companyUsersList;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "companyInfo")
+    private List<Recruit> recruits;
+}

--- a/src/main/java/com/hanium/hfrecruit/domain/company/CompanyUser.java
+++ b/src/main/java/com/hanium/hfrecruit/domain/company/CompanyUser.java
@@ -1,0 +1,29 @@
+package com.hanium.hfrecruit.domain.company;
+
+import com.hanium.hfrecruit.domain.Recruit.Recruit;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class CompanyUser {
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long companyUserId;
+
+    private Integer companyUserCode;
+
+    @ManyToOne
+    @JoinColumn(name = "company_no")
+    private CompanyInfo companyInfo;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "companyUser")
+    private List<Recruit> recruits;
+
+}

--- a/src/main/java/com/hanium/hfrecruit/domain/oauth/Oauth.java
+++ b/src/main/java/com/hanium/hfrecruit/domain/oauth/Oauth.java
@@ -1,0 +1,26 @@
+package com.hanium.hfrecruit.domain.oauth;
+
+import com.hanium.hfrecruit.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+
+public class Oauth {
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long tokenNo;
+
+    @Column(nullable = false)
+    private String accessToken;
+
+    @ManyToOne
+    @JoinColumn(name = "user_no")
+    private User user;
+}

--- a/src/main/java/com/hanium/hfrecruit/domain/spec/PersonalSpec.java
+++ b/src/main/java/com/hanium/hfrecruit/domain/spec/PersonalSpec.java
@@ -1,0 +1,38 @@
+package com.hanium.hfrecruit.domain.spec;
+
+import com.hanium.hfrecruit.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.Date;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class PersonalSpec {
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long personalSpecId;
+
+    @Column(nullable = false)
+    private Date certifiedDate;
+
+    @Column(nullable = false)
+    private Date authDate;
+
+    @Column(nullable = true)
+    private Integer score;
+
+    @ManyToOne
+    @JoinColumn(name = "user_no")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "spec_id")
+    private Spec spec;
+
+}

--- a/src/main/java/com/hanium/hfrecruit/domain/spec/Spec.java
+++ b/src/main/java/com/hanium/hfrecruit/domain/spec/Spec.java
@@ -1,0 +1,36 @@
+package com.hanium.hfrecruit.domain.spec;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Spec {
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+
+    private Long specId;
+
+    @Column(nullable = false)
+    private String spceName;
+
+    @Column(nullable = false)
+    private String institution;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "spec")
+    private List<PersonalSpec> personalSpecs;
+
+    @Builder
+    public Spec(String specName, String institution ) {
+        this.spceName = specName;
+        this.institution = institution;
+    }
+}

--- a/src/main/java/com/hanium/hfrecruit/domain/user/User.java
+++ b/src/main/java/com/hanium/hfrecruit/domain/user/User.java
@@ -1,10 +1,12 @@
 package com.hanium.hfrecruit.domain.user;
 
+import com.hanium.hfrecruit.domain.spec.PersonalSpec;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
@@ -14,14 +16,30 @@ import javax.persistence.*;
 public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
-
     private Long userNo;
+
+    @Column(nullable = false)
     private String userId;
+
+    @Column(nullable = false)
     private String userPw;
+
+    @Column(nullable = false)
     private String username;
+
+    @Column(nullable = false)
     private String college;
+
+    @Column(nullable = false)
     private String highschool;
+
+    @Column(nullable = false)
     private String birth;
+
+    @Column(nullable = false)
     private Integer gender;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
+    private List<PersonalSpec> personalSpecs;
 
 }


### PR DESCRIPTION
기존 테스트용 user포함해서 oauth, company_info, company_user, personal_spec, spec, application, recruit의 entity class를 설계했던 erd diagram에 맞게 추가함